### PR TITLE
Add release note for Duration block Restart input port [PAB-4727]

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
@@ -19,11 +19,11 @@ The **Duration** block in Analytics Builder has been enhanced with a new **Resta
 
 Previously, the only way to reset the measurement was using the **Reset** input port, which deactivates the block and requires a new **Start** signal to resume measurement. The new **Restart** input port provides more flexible control over the block's behavior in scenarios where you need to reset the elapsed time while keeping the block active.
 
-**New Input Port:**
+**New Input port:**
 
 - **Restart** (pulse): Resets the elapsed duration and immediately restarts measurement from this point, without deactivating the block. The block remains active and continues processing other input signals.
 
-**Existing Behavior (unchanged):**
+**Existing behavior (unchanged):**
 
 - **Reset** (pulse): Deactivates and resets the state of the block. A new **Start** signal is required to resume measurement.
 - **Start** (pulse): Activates the block and begins measurement.
@@ -31,4 +31,4 @@ Previously, the only way to reset the measurement was using the **Reset** input 
 
 This enhancement maintains full backward compatibility. Existing Analytics Builder models using the Duration block will continue to work without any modifications, while new models can leverage the **Restart** input to achieve previously difficult workflows.
 
-See the description of the [Duration](https://cumulocity.com/docs/streaming-analytics/block-reference/#duration) block for detailed information.
+See the description of the [Duration](/streaming-analytics/block-reference/#duration) block for detailed information.

--- a/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
@@ -1,0 +1,41 @@
+---
+date: '2026-07-29'
+title: Duration block now provides a Restart input port to reset elapsed time without deactivation
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAB-4727
+version: 27.180.0
+environment_availability:
+  - label: eu-latest.cumulocity.com
+  - label: apj.cumulocity.com
+  - label: jp.cumulocity.com
+  - label: emea.cumulocity.com
+  - label: us.cumulocity.com
+  - label: cumulocity.com
+---
+
+The **Duration** block in Analytics Builder has been enhanced with a new **Restart** input port that allows you to reset the elapsed duration and immediately restart measurement from that point, without deactivating the block.
+
+Previously, the only way to reset the measurement was using the **Reset** input port, which deactivates the block and requires a new **Start** signal to resume measurement. The new **Restart** input port provides more flexible control over the block's behavior in scenarios where you need to reset the elapsed time while keeping the block active.
+
+**New Input Port:**
+
+- **Restart** (pulse): Resets the elapsed duration and immediately restarts measurement from this point, without deactivating the block. The block remains active and continues processing other input signals.
+
+**Existing Behavior (unchanged):**
+
+- **Reset** (pulse): Deactivates and resets the state of the block. A new **Start** signal is required to resume measurement.
+- **Start** (pulse): Activates the block and begins measurement.
+- **Measure** (pulse): Outputs the current duration in seconds since activation (or last restart).
+
+This enhancement maintains full backward compatibility. Existing Analytics Builder models using the Duration block will continue to work without any modifications, while new models can leverage the **Restart** input to achieve previously difficult workflows.
+
+See the description of the [Duration](https://cumulocity.com/docs/streaming-analytics/block-reference/#duration) block for detailed information.

--- a/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
@@ -12,7 +12,7 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAB-4727
-version: 
+version: 27.206.0
 ---
 
 The **Duration** block in Analytics Builder has been enhanced with a new **Restart** input port that allows you to reset the elapsed duration and immediately restart measurement from that point, without deactivating the block.

--- a/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md
@@ -1,5 +1,5 @@
 ---
-date: '2026-07-29'
+date: 
 title: Duration block now provides a Restart input port to reset elapsed time without deactivation
 change_type:
   - value: change-2c7RdTdXo4
@@ -12,14 +12,7 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAB-4727
-version: 27.180.0
-environment_availability:
-  - label: eu-latest.cumulocity.com
-  - label: apj.cumulocity.com
-  - label: jp.cumulocity.com
-  - label: emea.cumulocity.com
-  - label: us.cumulocity.com
-  - label: cumulocity.com
+version: 
 ---
 
 The **Duration** block in Analytics Builder has been enhanced with a new **Restart** input port that allows you to reset the elapsed duration and immediately restart measurement from that point, without deactivating the block.


### PR DESCRIPTION
Add release note documenting the new Restart input port for the Duration block in Analytics Builder.

## Summary
The Duration block now provides a new Restart input port that allows resetting the elapsed duration and immediately restarting measurement from that point, without deactivating the block.

## Related PRs
- apama-in-c8y PR #7617: Implementation of the Restart input port feature

## Changes
- Added release note: `content/change-logs/analytics/apama-in-c8y-20260729-Duration-block-restart-without-deactivation.md`

## Details
- **Feature**: Duration block Restart input port
- **Jira Issue**: PAB-4727
- **Type**: Improvement
- **Version**: 27.180.0
- **Backward Compatible**: Yes - existing models continue to work unchanged