### PR TITLE
[DM-7021]: Announce deprecation of availability views

### DIFF
--- a/content/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts.md
+++ b/content/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts.md
@@ -1,0 +1,47 @@
+---
+date: '2026-08-10'
+title: Deprecation of device availability views
+product_area: Device management & connectivity
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-7021
+version:
+environment_availability:
+  - label: eu-latest.cumulocity.com
+  - label: apj.cumulocity.com
+  - label: jp.cumulocity.com
+  - label: emea.cumulocity.com
+  - label: us.cumulocity.com
+  - label: cumulocity.com
+---
+**Context**
+
+The Device Management application currently provides two views for monitoring device availability based on raised and cleared critical alarms: the **Availability** tab on individual device detail pages, and the **Availability** page under the **Devices** menu in the navigator. Both views are powered by the legacy AngularJS `c8y.parts.availability` module.
+
+**Change**
+
+The per-device **Availability** tab and the fleet-wide **Devices > Availability** page are now deprecated. The underlying AngularJS module `c8y.parts.availability` (including the `availabilityReportCtrl` controller and associated views) is marked as deprecated in the codebase. The feature will remain available through y2027 and is planned for removal thereafter.
+
+**Consequence**
+
+Existing tenants and users will continue to see the Availability views until the removal date. No immediate action is required. After removal, the views will no longer be accessible in the Device Management application. The underlying alarm-based availability data remains available via the [Cumulocity IoT REST API](https://{{< domain-c8y >}}/api/core/#tag/Alarms).
+
+**Persona**
+
+This deprecation affects **Device Management application users** who rely on the Availability views for operational monitoring, as well as **developers** who have built custom applications referencing the `c8y.parts.availability` AngularJS module from the `@c8y/ng1-modules` package.
+
+**Action**
+
+- **End users**: No action required before the removal date. After removal, use alarm-based monitoring via the REST API or build custom dashboards using the data.
+- **Developers** who import or extend the `c8y.parts.availability` module from `@c8y/ng1-modules`: plan to remove those dependencies before y2027.
+
+**Documentation**
+
+See [Availability](/device-management-application/monitoring-and-controlling-devices/#availability) in the Device Management documentation.

--- a/content/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts.md
+++ b/content/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts.md
@@ -31,11 +31,11 @@ The per-device **Availability** tab and the fleet-wide **Devices > Availability*
 
 **Consequence**
 
-Existing tenants and users will continue to see the Availability views until the removal date. No immediate action is required. After removal, the views will no longer be accessible in the Device Management application. The underlying alarm-based availability data remains available via the [Cumulocity IoT REST API](https://{{< domain-c8y >}}/api/core/#tag/Alarms).
+Existing tenants and users will continue to see the availability views until the removal date. No immediate action is required. After removal, the views will no longer be accessible in the Device Management application. The underlying alarm-based availability data remains available via the [{{< product-c8y-iot >}} REST API](https://{{< domain-c8y >}}/api/core/#tag/Alarms).
 
 **Persona**
 
-This deprecation affects **Device Management application users** who rely on the Availability views for operational monitoring, as well as **developers** who have built custom applications referencing the `c8y.parts.availability` AngularJS module from the `@c8y/ng1-modules` package.
+This deprecation affects **Device Management application users** who rely on the availability views for operational monitoring, as well as **developers** who have built custom applications referencing the `c8y.parts.availability` AngularJS module from the `@c8y/ng1-modules` package.
 
 **Action**
 

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/availability.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/availability.md
@@ -8,6 +8,10 @@ helpcontent:
   content: "Availability shows the availability across all devices for the last 24 hours, last 7 days and last 30 days. The availability is based on raised and cleared alarms and shown in percentage."
 ---
 
+{{< c8y-admon-info >}}
+The **Availability** tab on device detail pages and the **Devices > Availability** page are deprecated and planned for removal in y2027. See the [deprecation announcement](/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts) for details.
+{{< /c8y-admon-info >}}
+
 {{< product-c8y-iot >}} distinguishes between connection monitoring and availability. Connection monitoring, as described in the previous section, only indicates if the device is communicating with {{< product-c8y-iot >}}, it does not automatically indicate if it is functional or not.
 
 Availability indicates if a device is in service. For example, a vending machine is in service if it is ready to sell goods. A vending machine can sell goods using cash money without a connection to {{< product-c8y-iot >}}. From the perspective of a merchant, it is in service. Similar, if you switch off the power on a gateway, the devices behind the gateway can still continue to work.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/availability.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/availability.md
@@ -9,7 +9,7 @@ helpcontent:
 ---
 
 {{< c8y-admon-info >}}
-The **Availability** tab on device detail pages and the **Devices > Availability** page are deprecated and planned for removal in y2027. See the [deprecation announcement](/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts) for details.
+The **Availability** tab on device detail pages and the **Devices > Availability** page are deprecated and planned for removal before the y2028 release. See the [deprecation announcement](/change-logs/#ui-c8y-DM-7021-deprecate-availability-donut-charts) for details.
 {{< /c8y-admon-info >}}
 
 {{< product-c8y-iot >}} distinguishes between connection monitoring and availability. Connection monitoring, as described in the previous section, only indicates if the device is communicating with {{< product-c8y-iot >}}, it does not automatically indicate if it is functional or not.

--- a/content/device-management-application/viewing-device-details.md
+++ b/content/device-management-application/viewing-device-details.md
@@ -55,6 +55,10 @@ For more details about smart rules (NEW), refer to [Smart rules plugin](/streami
 
 ### Availability {#availability}
 
+{{< c8y-admon-info >}}
+The **Availability** tab is deprecated and planned for removal in y2027. See the [deprecation announcement](/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts) for details.
+{{< /c8y-admon-info >}}
+
 The Availability tab offers availability monitoring for machines, see [Availability](/device-management-application/monitoring-and-controlling-devices/#availability) for more information.
 
 ### Child devices {#child-devices}

--- a/content/device-management-application/viewing-device-details.md
+++ b/content/device-management-application/viewing-device-details.md
@@ -56,7 +56,7 @@ For more details about smart rules (NEW), refer to [Smart rules plugin](/streami
 ### Availability {#availability}
 
 {{< c8y-admon-info >}}
-The **Availability** tab is deprecated and planned for removal in y2027. See the [deprecation announcement](/change-logs/device-management/ui-c8y-DM-7021-deprecate-availability-donut-charts) for details.
+The **Availability** tab is deprecated and planned for removal before the y2028 release. See the [deprecation announcement](/change-logs/#ui-c8y-DM-7021-deprecate-availability-donut-charts) for details.
 {{< /c8y-admon-info >}}
 
 The Availability tab offers availability monitoring for machines, see [Availability](/device-management-application/monitoring-and-controlling-devices/#availability) for more information.


### PR DESCRIPTION
## Summary

- Adds deprecation announcement change-log entry (`Announcement` type) for the per-device **Availability** tab and the fleet-wide **Devices > Availability** page
- Adds deprecation info box to the [Availability](/device-management-application/monitoring-and-controlling-devices/#availability) docs page
- Adds deprecation info box to the Availability tab section in [Viewing device details](/device-management-application/viewing-device-details/#availability)

Removal is planned for y2027 and tracked in DM-6861.

## Test plan

- [ ] Change-log entry renders correctly with `Announcement` change type
- [ ] Info boxes appear on both doc pages
- [ ] Links to the announcement resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)