### PR TITLE
docs: redirect three moved pages that were returning 404

### DIFF
--- a/content/cloud-remote-access/setting-up-cloud-remote-access.md
+++ b/content/cloud-remote-access/setting-up-cloud-remote-access.md
@@ -4,6 +4,8 @@ weight: 30
 layout: bundle
 sector:
   - device_management
+aliases:
+  - /cloud-remote-access/using-cloud-remote-access/
 ---
 
 Cloud Remote Access is available in the [Device Management application](/device-management-application).

--- a/content/device-integration/lpwan.md
+++ b/content/device-integration/lpwan.md
@@ -4,4 +4,6 @@ title: LPWAN
 layout: bundle
 sector:
   - device_management
+aliases:
+  - /device-integration/lora-actility/
 ---

--- a/content/thin-edge/device-integration-thin-edge.md
+++ b/content/thin-edge/device-integration-thin-edge.md
@@ -5,6 +5,8 @@ layout: bundle
 slug: thin-edge
 sector:
   - device_management
+aliases:
+  - /device-integration/device-integration-thin-edge/
 ---
 
 To learn more about device integration using thin-edge.io, refer to [thin-edge.io - The open edge framework for lightweight IoT devices](https://thin-edge.io/).


### PR DESCRIPTION
## What

Adds a Hugo `aliases` entry on three pages so that three URLs which currently answer **404** redirect to the content that replaced them.

## Why

These three URLs still earn Google traffic and return nothing. **None of the pages was deleted** — each one moved, so the content is live under a new path and only the redirect is missing.

Search Console, May–Sep 2025 compared against Mar–Jul 2026:

| URL answering 404 | Clicks |
|---|---|
| `/docs/device-integration/device-integration-thin-edge/` | **190 → 0** |
| `/docs/device-integration/lora-actility/` | 38 → 0 |
| `/docs/cloud-remote-access/using-cloud-remote-access/` | 24 → 0 |

Worth roughly 600 clicks a year. They were found by probing the 25 current-version pages that lost at least half their clicks over that period — exactly 3 of the 25 are 404.

## Where each one goes

Destinations confirmed by matching the archived original's `<h1>` against the live current page, not by guessing at the path:

| Old page (h1) | Destination (h1) |
|---|---|
| Thin-edge.io | Device integration using thin-edge.io |
| Actility LoRa | LPWAN, under `#actility-lora` |
| Using Cloud Remote Access | Setting up Cloud Remote Access (CRA) |

Each alias emits a `<link rel="canonical">` at its destination as well as the meta refresh, so Google consolidates the old URL into the new one rather than only bouncing the visitor.

## Known limitation

The LoRa alias lands on `/docs/device-integration/lpwan/` rather than its `#actility-lora` anchor — a Hugo alias redirects to a page permalink and cannot carry a fragment. The Actility content is on that page, further down. Better than a 404, not perfect.

## Verification

Built this branch and an untouched `develop` baseline in a separate worktree, then diffed the file lists and the contents of every file present in both.

- **Added: exactly the three alias pages.** Removed: nothing.
- Each emits a meta refresh and a canonical pointing at the right destination.
- All three destination pages still build.

Note that a Hugo alias answers **HTTP 200** with a meta refresh, so a status-code check alone will not show it working — the canonical is the part search engines act on.

## Follow-up, not in this PR

The build diff surfaced an unrelated bug: on `content/quick-start/first-steps.md`, headings that contain a shortcode emit anchor IDs built from Hugo's internal placeholder, and the counter shifts between builds (`hahahugoshortcode339s2hbhb` → `hahahugoshortcode361s2hbhb`). Those anchors are unstable, so any deep link to them breaks on the next build. An explicit `{#my-heading}` ID would fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)