### PR TITLE
seo: noindex the archived 2026 release documentation

### DIFF
--- a/themes/c8ydocs/layouts/partials/head.html
+++ b/themes/c8ydocs/layouts/partials/head.html
@@ -35,7 +35,13 @@
     <link rel="manifest" href="{{"images/favicon/site.webmanifest" | absURL}}">
 
 
-    <link rel="canonical" href="{{ .Permalink }}">
+    {{ if eq $version "Latest" }}
+      <link rel="canonical" href="{{ .Permalink }}">
+    {{ else }}
+      {{/* Archived release. Keep it out of search results so it cannot outrank
+           the equivalent page in the current documentation. */}}
+      <meta name="robots" content="noindex">
+    {{ end }}
 
     <meta name="msapplication-TileColor" content="#212121">
     <meta name="theme-color" content="#ffbe00">


### PR DESCRIPTION
## What

On archived release builds, `partials/head.html` now emits `<meta name="robots" content="noindex">` instead of a canonical. The current documentation keeps its canonical, unchanged.

```
{{ if eq $version "Latest" }}
  <link rel="canonical" href="{{ .Permalink }}">
{{ else }}
  <meta name="robots" content="noindex">
{{ end }}
```

## Why

The archived copies compete with the current documentation for the same queries, win, and then convert about 3× worse. Worth an estimated 2,350–3,040 clicks a year across the archives.

**This branch was the worst case.** It emitted a *self-referential* canonical on every content page — each archived page was telling Google it is the canonical version of itself. Confirmed live before the change: `/docs/2026/authentication/sso/` returned `<link rel="canonical" href="https://cumulocity.com/docs/2026/authentication/sso/">`. `release/y2025` and `release/y2024` emit no canonical at all, which is merely bad rather than actively wrong.

## Why `noindex` and not a canonical pointing at the current page

A canonical would be better *if* the target always existed. It doesn't: **16 of 246 `/docs/2026/` paths (6%) and 29 of 249 `/docs/2025/` paths (11%) have no equivalent** in the current 260-URL sitemap — whole sections (`edge/`, `edge-kubernetes/`, `protocol-integration/`, `glossary/`) moved or went away. A blanket canonical would aim those at a 404, where Google ignores it and the page keeps competing.

A release build also cannot see what the current build contains, so making it reliable would mean committing a generated path list to every release branch and keeping it fresh on every `develop` ship.

Google also advises against pairing `noindex` with a canonical — the two signals contradict each other.

**The pages stay reachable for customers on this release.** They only stop competing in search.

## The `$version` guard

`$version` already exists at `head.html:10` (`.Site.Data.date_settings.version`), used to build the page title. Reusing it means this one file is correct on `develop` (`"Latest"`) and on a release branch (`"2026"`), so an accidental graft in either direction is harmless rather than catastrophic.

## Verification

Built with **hugo 0.132.2** — the version pinned in `.github/workflows` — against an untouched `release/y2026` baseline, both with `-b https://cumulocity.com/docs/2026` to match production.

| Check | Result |
|---|---|
| File count | 963 → 963, nothing added or removed |
| Content pages swapping self-canonical → noindex | **186** |
| Pages with both tags | unchanged (76, all pre-existing redirect/alias stubs) |
| Remaining canonicals | all Hugo alias stubs |
| GSC site-verification file | untouched |

`/docs/2026/authentication/sso/` — the page probed live — goes from `noindex:false, canonical:self` to `noindex:true, canonical:none`.

## 🔴 Merging is not shipping

The archive is already-built output rsynced to a static server. **This branch must be rebuilt and redeployed** before anything changes for Google. Merging alone does nothing.

## Known loose end

16 Hugo alias stubs on this branch keep a canonical and have no `noindex` — they point at pages that are now `noindex`, so Google folds them into a `noindex` target and drops them. Self-resolving; not worth an `alias.html` override.

## Related

- Archived sitemaps for 2024 and 2025 were removed from Search Console on 2026-08-24 (526 URLs withdrawn from the crawl hint).
- 2024 is planned for retirement the way `/guides` was done — a catch-all 301 — so it deliberately gets no equivalent change.
