### PR TITLE
seo: noindex the archived 2025 release documentation

### DIFF
--- a/themes/c8ydocs/layouts/partials/head.html
+++ b/themes/c8ydocs/layouts/partials/head.html
@@ -33,6 +33,14 @@
     <link rel="shortcut icon" href="{{"images/favicon/favicon.ico" | absURL}}">
     <link rel="mask-icon" href="{{"images/favicon/safari-pinned-tab.svg" | absURL}}" color="#212121">
     <link rel="manifest" href="{{"images/favicon/site.webmanifest" | absURL}}">
+
+    {{ if eq $version "Latest" }}
+      <link rel="canonical" href="{{ .Permalink }}">
+    {{ else }}
+      {{/* Archived release. Keep it out of search results so it cannot outrank
+           the equivalent page in the current documentation. */}}
+      <meta name="robots" content="noindex">
+    {{ end }}
     <meta name="msapplication-TileColor" content="#212121">
     <meta name="theme-color" content="#ffbe00">
     <meta name="msapplication-TileColor" content="#212121">


### PR DESCRIPTION
## What

The same change as [#5073](https://github.com/Cumulocity-IoT/c8y-docs/pull/5073), applied to `release/y2025`. On archived builds `partials/head.html` now emits `<meta name="robots" content="noindex">`; the current documentation keeps its canonical.

```
{{ if eq $version "Latest" }}
  <link rel="canonical" href="{{ .Permalink }}">
{{ else }}
  <meta name="robots" content="noindex">
{{ end }}
```

The inserted block is byte-identical to the one in #5073, so the two release branches converge on the same theme file.

## Why

The archived copies compete with the current documentation for the same queries, win, and convert about 3× worse. Unlike `release/y2026`, **this branch emitted no canonical at all** on content pages — nothing told Google which copy to prefer.

## Why `noindex` and not a canonical pointing at the current page

**29 of the 249 paths here (11%) have no equivalent** in the current 260-URL sitemap, so a blanket canonical would aim those at a 404, where Google ignores it and the page keeps competing. A release build also cannot see what the current build contains. Google advises against pairing `noindex` with a canonical in any case.

**The pages stay reachable for customers on this release.** They only stop competing in search.

## Verification

Built with **hugo 0.132.2** — the version pinned in `.github/workflows` — against an untouched `release/y2025` baseline, both with `-b https://cumulocity.com/docs/2025`.

| Check | Result |
|---|---|
| File count | 954 → 954, nothing added or removed |
| Pages carrying `noindex` | **82 → 270** |
| Canonical count | unchanged at 82, all alias and redirect stubs |
| Pages with neither tag | 2, both pre-existing (GSC verification file, Netlify CMS stub) |

## ⚠️ This branch does not build with current Hugo

Worth knowing before anyone tries. Hugo **0.158.0 fails outright**:

```
ERROR error building site: assemble: failed to create page from pageMetaSource
/authentication/basic-settings: tab character cannot be used for indentation
in double-quoted text
```

A pre-existing tab-indented YAML scalar in `content/authentication/basic-settings.md`; 41 files on this branch have leading tabs. **Use the pinned 0.132.2**, which is what CI and the deploy image use. Not fixed here — unrelated to this change, and it would mean editing archived content.

## 🔴 Merging is not shipping

The archive is already-built output rsynced to a static server. **This branch must be rebuilt and redeployed** before anything changes for Google.

## Related

- [#5073](https://github.com/Cumulocity-IoT/c8y-docs/pull/5073) — the same change on `release/y2026`. Merge that one first; it is the larger, more-linked archive.
- Archived sitemaps for 2024 and 2025 were removed from Search Console on 2026-08-24.
- 2024 is planned for retirement the way `/guides` was done — a catch-all 301 — so it deliberately gets no equivalent change.
