### PR TITLE
docs: give three first-steps headings stable anchor IDs

### DIFF
--- a/content/quick-start/first-steps.md
+++ b/content/quick-start/first-steps.md
@@ -11,7 +11,7 @@ The following section highlights the basic steps to take if you are new to the {
 If you are technically interested in our IoT platform, you might want to learn about the architecture, technical concepts and domain models behind {{< product-c8y-iot >}} described in [Technical concepts](/concepts/concepts-introduction/).
 
 
-### Step 1: Logging into {{< product-c8y-iot >}} for the first time
+### Step 1: Logging into {{< product-c8y-iot >}} for the first time {#step-1-logging-in-for-the-first-time}
 
 To log in to the {{< product-c8y-iot >}} platform and access your tenant, use the following URL:
 
@@ -29,7 +29,7 @@ Click **Login** to enter the {{< product-c8y-iot >}} platform. Initially, you wi
 
 Go to [Accessing and logging into the platform](/get-familiar-with-the-ui/platform-access/) for more details on supported URLs, password reset, and more.
 
-### Step 2: Learn about {{< product-c8y-iot >}}'s basic UI functionalities and features
+### Step 2: Learn about {{< product-c8y-iot >}}'s basic UI functionalities and features {#step-2-basic-ui-functionalities-and-features}
 
 #### Main screen elements
 
@@ -69,7 +69,7 @@ Moreover, we offer two step-by-step descriptions to easily register a first devi
 
 For the purpose of this tutorial, we will register a device via the {{< sensor-app >}}.
 
-#### Connecting a smartphone with the {{< sensor-app >}}
+#### Connecting a smartphone with the {{< sensor-app >}} {#connecting-a-smartphone-with-the-sensor-app}
 
 The {{< sensor-app >}} is designed to collect measurements from your smartphone, nearby Bluetooth device sensors, and vehicle On-board Debug (OBD) sensors, and send them to the {{< product-c8y-iot >}} platform. The {{< sensor-app >}} can also send commands to the smartphone directly from the phone dashboard.
 


### PR DESCRIPTION
Three headings on [/docs/quick-start/first-steps/](https://cumulocity.com/docs/quick-start/first-steps/) contain shortcodes, so Hugo builds their anchor IDs out of its internal shortcode placeholder. Live production right now:

```
id="step-1-logging-into-hahahugoshortcode1979s2hbhb-for-the-first-time"
id="step-2-learn-about-hahahugoshortcode1979s8hbhbs-basic-ui-functionalities-and-features"
id="connecting-a-smartphone-with-the-hahahugoshortcode1979s20hbhb"
```

**The counter is not stable.** Production serves `1979`; a local build of `develop` produces `343`. So every deep link into those three sections breaks on the next build, and the copy-link button next to each heading hands the reader a URL that is already doomed.

Explicit `{#...}` IDs fix it, following the `{#account-settings}` precedent already on the same page. The IDs leave the product name out, so a future rename cannot break them again.

### Verification

Built this branch and an untouched `develop` in a throwaway worktree, then diffed:

- only `quick-start/first-steps/index.html` and `llms-full.txt` differ (plus `style.css.map`, whose sourcemap embeds the build path)
- `grep -r hahahugoshortcode` over the whole new build returns **nothing**
- `node scripts/lint-llmstxt.mjs` passes on the hub and all seven sector spokes

### Not fixed here

- `llms-full.txt` prints heading IDs as literal `{#id}` text. Pre-existing and repo-wide — **504 headings** already do this on `develop`; this PR adds 3. It is a template fix, not a content fix.
- `content/device-integration/mqtt-bundle/mqtt-examples.md:1073` uses a shortcode inside a fenced code block, which *CLAUDE.md* forbids. Not a heading, so no anchor impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)