### PR TITLE
seo: retire Release 2024 from the documentation UI

### DIFF
--- a/content/about_documentation/documentation-repository.md
+++ b/content/about_documentation/documentation-repository.md
@@ -12,17 +12,17 @@ This {{< product-c8y-iot >}} documentation website provides the documentation fo
 
 The user documentation for previous releases which are out of maintenance is available in a  GitHub repository called [c8y-docs]({{< link-c8y-github >}}/c8y-docs) which stores the documentation sources. The c8y-docs repository is public which means that no credentials are required to access it.
 
-The user documentation is available in the [Releases]({{< link-c8y-github >}}/c8y-docs/releases) section of the repository for all release versions that are no longer maintained. It is provided as a ZIP file called *c8y-guides-&lt;release-version&gt;.zip*, for example, *c8y-guides-10-18-0.zip*.
+The user documentation is available in the [Releases]({{< link-c8y-github >}}/c8y-docs/releases) section of the repository for all release versions that are no longer maintained. It is provided as a ZIP file called *c8y-guides-&lt;release-version&gt;.zip*, for example, *c8y-guides-10-18-0.zip*. For yearly releases, the file is called *c8y-docs-&lt;year&gt;.zip*, for example, *c8y-docs-2024.zip*.
 
 {{< c8y-admon-info >}}
 Documentation ZIP files are available in the **Releases** section for the following {{< product-c8y-iot >}} release versions:
 
-10.18.0, 10.17.0, 10.16.0, 10.15.0, 10.14.0, 10.13.0, 10.11.0, 10.10.0, 10.9.0, 10.7.0, 10.6.6, 10.6.0, 10.5.7, 10.5.0, 10.4.6
+2024, 10.18.0, 10.17.0, 10.16.0, 10.15.0, 10.14.0, 10.13.0, 10.11.0, 10.10.0, 10.9.0, 10.7.0, 10.6.6, 10.6.0, 10.5.7, 10.5.0, 10.4.6
 {{< /c8y-admon-info >}}
 
 #### Add the documentation as custom application to your tenant {#add-the-documentation-as-custom-application-to-your-tenant}
 
-1. In the [Releases]({{< link-c8y-github >}}/c8y-docs/releases) section of the c8y-docs repository, select the release version and download the ZIP file (*c8y-guides-&lt;release-version&gt;.zip*) from the Assets list.
+1. In the [Releases]({{< link-c8y-github >}}/c8y-docs/releases) section of the c8y-docs repository, select the release version and download the ZIP file from the Assets list.
 2. Log in to your {{< product-c8y-iot >}} tenant.
 3. In the Administration application, navigate to **Ecosystem** > **Applications**.
 4. Click **Add application** on the top right and select **Upload web application**.
@@ -32,7 +32,7 @@ Once uploaded, the application is created and available in the application list 
 
 #### Access the documentation in a web browser {#access-the-documentation-in-a-web-browser}
 
-1. In the [Releases]({{< link-c8y-github >}}/c8y-docs/releases) section of the c8y-docs repository, select the release version and download the ZIP file (*c8y-guides-&lt;release-version&gt;.zip*) from the Assets list.
+1. In the [Releases]({{< link-c8y-github >}}/c8y-docs/releases) section of the c8y-docs repository, select the release version and download the ZIP file from the Assets list.
 2. Open the ZIP file in a browser.
 3. Double-click the file named "index.html" in the root folder. It will open in your default browser.
 

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -90,12 +90,6 @@
             <span>Release 2025</span> 
           </a>
         </li>
-        <li class="text-normal">
-          <a class='icon-flex {{ if eq $currentVersion "2024" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2024">
-            {{ if eq $currentVersion "2024" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
-            <span>Release 2024</span> 
-          </a>
-        </li>
         <li class="text-normal"><a class="icon-flex p-l-24" href="//cumulocity.com/docs/about_documentation/documentation-repository/">
           <span>Previous versions</span>
         </a></li>
@@ -192,11 +186,6 @@
         <li class="text-normal">
           <a class="dd-link" href="//cumulocity.com/docs/2025">
             <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2025 {{ if eq $currentVersion "2025" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
-          </a>
-        </li>
-        <li class="text-normal">
-          <a class="dd-link" href="//cumulocity.com/docs/2024">
-            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2024 {{ if eq $currentVersion "2024" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
           </a>
         </li>
         <li class="text-normal">


### PR DESCRIPTION
Part of retiring the 2024 archive. The full 2024 documentation stays available as [release `v2024`](https://github.com/Cumulocity-IoT/c8y-docs/releases/tag/v2024).

### The dropdown is hardcoded

`header.html` does not build the release list from data — it is a literal `<li>` per version, and **the list appears twice**: once in the desktop dropdown, once in the collapsed menu. Both 2024 entries are removed. No reference to `/docs/2024` remains anywhere in the theme.

### The "Previous versions" page did not describe the 2024 ZIP

`documentation-repository.md` is the customer-facing route for retired documentation. It listed versions up to 10.18.0 with no 2024 entry, and stated the asset is always named `c8y-guides-<release-version>.zip`. **The 2024 asset is `c8y-docs-2024.zip`**, so anyone following the instructions looked for a filename that does not exist. The page now names both patterns, lists 2024, and the two download steps no longer hard-code a filename.

### Verification

Built this branch against one from untouched `develop`:

- **197 of 280 HTML pages change**, and they are exactly the pages that render the header — the other 83 are bundle fragments with no header (confirmed: 0 occurrences of `Release 2026` in them)
- `Release 2024` and `cumulocity.com/docs/2024` appear **nowhere** in the built site
- the only non-HTML change is `llms-full.txt`, carrying the same four content edits

### Noticed, not fixed

`{{< link-c8y-github >}}` renders with a trailing slash, so the built links read `https://github.com/Cumulocity-IoT//c8y-docs/releases` — a double slash. Pre-existing on `develop`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)