### PR TITLE
seo: drop Release 2024 from the releases dropdown

### DIFF
--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -90,12 +90,6 @@
             <span>Release 2025</span> 
           </a>
         </li>
-        <li class="text-normal">
-          <a class='icon-flex {{ if eq $currentVersion "2024" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2024">
-            {{ if eq $currentVersion "2024" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
-            <span>Release 2024</span> 
-          </a>
-        </li>
         <li class="text-normal"><a class="icon-flex p-l-24" href="//cumulocity.com/docs/about_documentation/documentation-repository/">
           <span>Previous versions</span>
         </a></li>
@@ -192,11 +186,6 @@
         <li class="text-normal">
           <a class="dd-link" href="//cumulocity.com/docs/2025">
             <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2025 {{ if eq $currentVersion "2025" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
-          </a>
-        </li>
-        <li class="text-normal">
-          <a class="dd-link" href="//cumulocity.com/docs/2024">
-            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2024 {{ if eq $currentVersion "2024" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
           </a>
         </li>
         <li class="text-normal">


### PR DESCRIPTION
**merging rebuilds and redeploys the whole 2025 archive** (`staging.yml` runs on push to `release/y**`, and the upload is `rsync --delete-after`).

Part of retiring the 2024 archive. The full 2024 documentation stays available as [release `v2024`](https://github.com/Cumulocity-IoT/c8y-docs/releases/tag/v2024).

The dropdown is hardcoded in `header.html`, not built from data, and **the release list appears twice** — once in the desktop dropdown, once in the collapsed menu. Both 2024 entries are removed. `grep -c 'docs/2024'` on the file goes from 2 to 0, and no other reference remains in the theme.

Companion PRs: #5076 (`develop`, which also documents the 2024 ZIP on the *Previous versions* page) and the equivalent on the other archive branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)