### PR TITLE
fix: dead and mis-targeted links in the docs navigation

### DIFF
--- a/content/changelogs.md
+++ b/content/changelogs.md
@@ -3,7 +3,7 @@ title: Change logs
 icon: "c8y-icon c8y-icon-cumulocity-iot"
 type: root
 layout: redirect
-target: "/change-logs"
+target: "change-logs/"
 sector:
   - change-logs
 weight: 10

--- a/content/glossary-card.md
+++ b/content/glossary-card.md
@@ -4,7 +4,7 @@ icon: "c8y-icon c8y-icon-book"
 type: root
 layout: redirect
 bundlefolder: glossary
-target: glossary
+target: "glossary/"
 sector:
   - getting_started
 audience:

--- a/themes/c8ydocs/layouts/_default/redirect.html
+++ b/themes/c8ydocs/layouts/_default/redirect.html
@@ -18,6 +18,12 @@
       {{ $sub := index $subs 0}}
       {{ $scratch.Set "url" $sub.Permalink}}
     {{ end }}
+    {{/* No section matched, so the refresh URL would be empty and the page would
+         reload itself forever. Use the external link if the page declares one,
+         otherwise send the reader to the documentation root. */}}
+    {{ if not ($scratch.Get "url") }}
+      {{ $scratch.Set "url" (or .Params.external .Site.BaseURL) }}
+    {{ end }}
     <meta http-equiv="refresh" content='0; URL={{ $scratch.Get "url"}}'/>
     <style>
       body{ 

--- a/themes/c8ydocs/layouts/partials/glossary-nav.html
+++ b/themes/c8ydocs/layouts/partials/glossary-nav.html
@@ -36,9 +36,19 @@
 
                 {{$rootclass := newScratch}}
                 {{/* grab the link from the first child page  */}}
+                {{ $scratch.Set "url" "" }}
                 {{ range $sub := first 1 $subs}}
                   {{ $scratch.Set "url" $sub.Permalink}}
                 {{end}}
+                {{/* Same fallback as root-nav.html: a section whose children set
+                     `build.render: false` exposes no child page to link to. */}}
+                {{ if not ($scratch.Get "url") }}
+                  {{ with .Params.target }}
+                    {{ $scratch.Set "url" (printf "%s%s" $.Site.BaseURL .) }}
+                  {{ else }}
+                    {{ $scratch.Set "url" $.Site.BaseURL }}
+                  {{ end }}
+                {{ end }}
 
                 {{/* Check the current page to highlight the right root section  */}}
                 {{$rootclass.Set "active" "" }}

--- a/themes/c8ydocs/layouts/partials/root-nav.html
+++ b/themes/c8ydocs/layouts/partials/root-nav.html
@@ -36,9 +36,21 @@
 
                 {{$rootclass := newScratch}}
                 {{/* grab the link from the first child page  */}}
+                {{ $scratch.Set "url" "" }}
                 {{ range $sub := first 1 $subs}}
                   {{ $scratch.Set "url" $sub.Permalink}}
                 {{end}}
+                {{/* Sections whose children set `build.render: false` expose no child
+                     page to link to - the glossary is one. Fall back to the root
+                     page's own `target`, then to the documentation root, so the item
+                     can never render with an empty href and do nothing when clicked. */}}
+                {{ if not ($scratch.Get "url") }}
+                  {{ with .Params.target }}
+                    {{ $scratch.Set "url" (printf "%s%s" $.Site.BaseURL .) }}
+                  {{ else }}
+                    {{ $scratch.Set "url" $.Site.BaseURL }}
+                  {{ end }}
+                {{ end }}
 
                 {{/* Check the current page to highlight the right root section  */}}
                 {{$rootclass.Set "active" "" }}


### PR DESCRIPTION
Four navigation defects. The first was reported by a reader; the others were found while resolving every target in the `/docs/2024/` retirement redirect map to its final destination.

### 1. "Glossary" in the sector dropdown does nothing

Reported: *"In the Getting started dropdown, clicking Glossary doesn't do anything."* It rendered with an **empty href**:

```html
<a class='dropdown-menu-item text-truncate ' href='
                    ' title="Glossary">
```

Both nav partials build the link from the first child page of the card's `bundlefolder`. `content/glossary/a.md` … `z.md` all set `build.render: false`, so `where .Site.Pages "Section" "glossary"` yields nothing, the scratch value is never set, and the href comes out blank. Neither partial ever read the card's `target`, which points at the page that *does* exist.

Both now fall back to `target`, then to the documentation root. `glossary-nav.html` needed it too — the glossary page renders its own nav, so the item was dead there as well.

Also fixed in passing: the scratch value is now cleared per iteration, so one card can no longer inherit the previous card's URL. That was latent in the same code.

**Measured across a full build: 29 pages carried the empty href before, 0 after, and no dropdown item anywhere in the site is left with an empty href.**

### 2. `/docs/welcome-developers-card/` reloads itself forever

```html
<meta http-equiv="refresh" content='0; URL='/>
```

An empty refresh URL, so the browser reloads the page, which emits the same tag, indefinitely. Same root cause as above — `bundlefolder: welcome-developers` matches no section — and the card's `external:` was never read by `redirect.html`. The layout now falls back to `external:`, then the documentation root, **only when the URL would be empty**, so no page that already resolves changes behaviour.

### 3 & 4. Two stubs cost an extra 301

| Page | Was | Now |
|---|---|---|
| `/docs/changelogs/` | `/docs//change-logs` — double slash, then a 301 | `/docs/change-logs/` |
| `/docs/glossary-card/` | `/docs/glossary` — no trailing slash, then a 301 | `/docs/glossary/` |

`target` is concatenated onto a `baseURL` that already ends in a slash, so a leading slash doubles it and a missing trailing slash costs a redirect.

### Verification

Built against an untouched `develop`:

- **no dropdown item anywhere has an empty href**, and no refresh with an empty URL remains in the build
- substantive changes are confined to the 29 `getting_started` pages, the glossary page, and the three redirect stubs
- every other affected page differs **only in whitespace** from the new template comments, confirmed by re-diffing with whitespace collapsed
- `sitemap.xml` shows 4 changed `lastmod` values — these come from file mtime, not content, and a CI checkout resets them

### Deliberately not changed

`/docs/c8y-iot-styleguide/` and `/docs/rest_api/` also declare `external:` but resolve to an unrelated in-docs page rather than an empty one — the styleguide lands on the service terms. That is a wrong destination rather than broken output, so it needs a decision about intent, not a template fallback.
