### PR TITLE
seo: index the Edge documentation on the 2026 archive

### DIFF
--- a/themes/c8ydocs/layouts/partials/head.html
+++ b/themes/c8ydocs/layouts/partials/head.html
@@ -37,9 +37,14 @@
 
     {{ if eq $version "Latest" }}
       <link rel="canonical" href="{{ .Permalink }}">
-    {{ else }}
+    {{ else if ne .Section "edge" }}
       {{/* Archived release. Keep it out of search results so it cannot outrank
-           the equivalent page in the current documentation. */}}
+           the equivalent page in the current documentation.
+
+           The Edge section is the exception: it exists on the yearly branches
+           only, so these pages are the only copy and have nothing to outrank.
+           Matching on .Section rather than the URL keeps this working on the
+           next yearly branch, where the baseURL prefix differs. */}}
       <meta name="robots" content="noindex">
     {{ end }}
 


### PR DESCRIPTION
## What this fixes

[#5073](https://github.com/Cumulocity-IoT/c8y-docs/pull/5073) added `noindex` to every page built from a yearly release branch, so an archived copy could not outrank the equivalent page in the current documentation. The Edge section has no equivalent page to outrank:

| Branch | `content/edge/` |
|---|---|
| `develop` | **0 files** |
| `release/y2025` | **0 files** |
| `release/y2026` | **61 files** (51 `.md` + 10 `headless: true` bundle wrappers) |

`develop` reaches Edge through a `type: new-tab` stub in `content/sector/edge_server/_index.md` pointing at `https://cumulocity.com/docs/2026/edge`. So #5073 removed a whole product area from Google instead of de-duplicating it. This excludes the section from the rule.

## Why `.Section` and not the URL

`.Section` is independent of the `baseURL` prefix, so the same edit works verbatim on the next yearly branch. No canonical is added — these pages are the only copy, so nothing competes with them, and the "no canonical on archives" decision stands everywhere else.

## Measured, before and after, on a full build of this branch

- page set **identical** — 264 HTML files both times
- **12 Edge pages lost `noindex`**: `architecture-concept`, `benchmarks`, `connecting-devices-to-edge`, `connecting-edge-to-cloud`, `edge-custom-resource-definition`, `edge-introduction`, `edge-operations`, `installing-edge`, `manage-edge`, `quickstart`, `troubleshooting-edge`, `using-edge`
- **0 pages gained `noindex`**
- 234 pages remain `noindex`, down from 246

`edge/index.html` stays `noindex` deliberately: it is a `layout: redirect` stub that refreshes to `edge/edge-introduction/`, and a redirector should not be indexed. Google follows the refresh to the introduction page, which is now indexable.

## One thing to plan for

When `release/y2027` lands and Edge moves to `/docs/2027/edge/`, the indexed 2026 pages become the stale duplicate outranking it — the exact problem #5073 existed to fix. Either this exclusion retires with each yearly rollover, or Edge moves to a stable `/docs/edge/` on `develop`. Note `data/date_settings.toml` on this branch carries a parallel Edge release timeline, so Edge lives on the yearly branch by design.

⚠️ Merging this **redeploys the whole 2026 archive** (`staging.yml` on push to `release/y**`).