### PR TITLE
docs(change-logs): DM-7085 [Improvement] Improved recovery of a timed out LWM2M firmware delivery

### DIFF
--- a/content/change-logs/device-management/lwm2m-agent-1022-5-8-improved-recovery-of-a-timed-out-lwm2m-firmware-delivery.md
+++ b/content/change-logs/device-management/lwm2m-agent-1022-5-8-improved-recovery-of-a-timed-out-lwm2m-firmware-delivery.md
@@ -1,0 +1,21 @@
+---
+date: ""
+title: Improved recovery of a timed out LWM2M firmware delivery
+product_area: Device management & connectivity
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: component-1KLUzmqfe
+    label: LWM2M
+build_artifact:
+  - value: tc-ggH2M4hf3
+    label: lwm2m-agent
+ticket: DM-7085
+version: 1022.5.8
+---
+The LWM2M agent gives each firmware delivery a limited amount of time to complete. When that time expired, the agent restarted the update process and asked the device for its firmware update state, which the process accepts only as **Idle**. A device that was still working on the transfer could not report **Idle**, so the operation failed with the misleading reason "Another firmware update process is still in progress".
+
+The agent now reads the firmware update state and the firmware update result of the device once the delivery time expires, and it continues based on what the device reports. A device that already holds the firmware gets the installation triggered instead of the image delivered a second time. A device that reports a firmware update error fails the operation with that error, so the failure names the reason reported by the device. A device that dropped the transfer gets its firmware update state machine reset and the firmware delivered again. A device that is still downloading fails the operation with a reason that names the expired delivery time, and a device that is offline gets checked again the next time it registers.
+
+Existing installations require no changes, and firmware updates that complete within the delivery time behave as before.

--- a/content/change-logs/device-management/lwm2m-agent-1022-5-8-improved-recovery-of-a-timed-out-lwm2m-firmware-delivery.md
+++ b/content/change-logs/device-management/lwm2m-agent-1022-5-8-improved-recovery-of-a-timed-out-lwm2m-firmware-delivery.md
@@ -16,6 +16,11 @@ version: 1022.5.8
 ---
 The LWM2M agent gives each firmware delivery a limited amount of time to complete. When that time expired, the agent restarted the update process and asked the device for its firmware update state, which the process accepts only as **Idle**. A device that was still working on the transfer could not report **Idle**, so the operation failed with the misleading reason "Another firmware update process is still in progress".
 
-The agent now reads the firmware update state and the firmware update result of the device once the delivery time expires, and it continues based on what the device reports. A device that already holds the firmware gets the installation triggered instead of the image delivered a second time. A device that reports a firmware update error fails the operation with that error, so the failure names the reason reported by the device. A device that dropped the transfer gets its firmware update state machine reset and the firmware delivered again. A device that is still downloading fails the operation with a reason that names the expired delivery time, and a device that is offline gets checked again the next time it registers.
+The agent now reads the firmware update state and the firmware update result of the device once the delivery time expires, and it continues based on what the device reports. 
+
+- A device that already holds the firmware gets the installation triggered instead of the image being delivered a second time. 
+- A device that reports a firmware update error fails the operation with that error, so the failure names the reason reported by the device. 
+- A device that dropped the transfer gets its firmware update state machine reset and the firmware delivered again. 
+- A device that is still downloading fails the operation with a reason that names the expired delivery time, and a device that is offline gets checked again the next time it registers.
 
 Existing installations require no changes, and firmware updates that complete within the delivery time behave as before.


### PR DESCRIPTION
Change log entry for the LWM2M firmware delivery timeout recovery.

Ticket: [DM-7085](https://cumulocity.atlassian.net/browse/DM-7085)
Original PR: [Cumulocity-IoT/c8y-lwm2m#634](https://github.com/Cumulocity-IoT/c8y-lwm2m/pull/634)

- Change type: **Improvement**, component **LWM2M**, build artifact **lwm2m-agent**
- `version: 1022.5.8` is the expected release of the fix (`develop` is at 1022.5.7 and the fix bumps the patch level). It needs a correction here if another patch of `c8y-lwm2m` is released before #634 merges.
- `date` is left empty for the deployment-dates automation to fill.
- The new `C8Y.lwm2m.fwupdate.firmwareDeliveryTimeout` Helm value that ships with the fix is deliberately not mentioned: it is an operator-level setting, is not documented in the user guides, and is not actionable for tenants on the public cloud.

AI usage disclosure: drafted with Claude Code against `.github/prompts/c8y-change-log-review.prompt.md` and the style guide in `.github/copilot-instructions.md`, then edited by hand.


[DM-7085]: https://cumulocity.atlassian.net/browse/DM-7085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ