### PR TITLE
MTM-67722 Fix identification of Core MQTT topics

### DIFF
--- a/content/change-logs/platform-services/mqtt-service-3000.0.18-fix-smartrest-topic-identification.md
+++ b/content/change-logs/platform-services/mqtt-service-3000.0.18-fix-smartrest-topic-identification.md
@@ -12,7 +12,7 @@ build_artifact:
   - value: tc-hc5Tfixeqqei
     label: mqtt-service
 ticket: MTM-67722
-version: 3000.0.19
+version: 3000.0.18
 ---
 The [MQTT Service](/device-integration/mqtt-service) treats a set of MQTT topic names as "Core MQTT" topics.
 These topics can only be used with Core MQTT protocols and must not be used by "generic MQTT" devices.

--- a/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
+++ b/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
@@ -17,7 +17,7 @@ version: 3000.0.19
 The [MQTT Service documentation](/device-integration/mqtt-service/#core-mqtt-topics) describes the set of MQTT topic names that will be treated as Core MQTT topics.
 These topics can only be used with Core MQTT protocols and must not be used by "generic" MQTT devices.
 
-Previously, topic names that were documented as being *prefixes* for Core MQTT topics were incorrectly matching any topic name *containing* the Core MQTT prefix.
+Previously, the MQTT Service incorrectly treated any topic name containing a Core MQTT prefix as a Core MQTT topic instead of matching the prefix only at the start of the topic name.
 For example, the topic name `sensors/12345` was treated as a Core MQTT topic because it contained the reserved topic prefix `s/`.
 
 In addition, some Core MQTT reserved topic names were incorrectly treated as prefixes when they are specific names for single topics.

--- a/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
+++ b/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
@@ -1,0 +1,27 @@
+---
+date: 
+title: Fix problems with the identification of Core MQTT topics
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Platform services
+component:
+  - value: component-LcWEQW5gs
+    label: MQTT
+build_artifact:
+  - value: tc-hc5Tfixeqqei
+    label: mqtt-service
+ticket: MTM-67722
+version: 3000.0.19
+---
+The [MQTT Service documentation](/device-integration/mqtt-service/#core-mqtt-topics) describes the set of MQTT topic names that will be treated as Core MQTT topics.
+These topics can only be used with Core MQTT protocols and must not be used by "generic" MQTT devices.
+
+Previously, topic names that were documented as being *prefixes* for Core MQTT topics were incorrectly matching any topic name *containing* the Core MQTT prefix.
+For example, the topic name `sensors/12345` was treated as a Core MQTT topic because it contained the reserved topic prefix `s/`.
+
+In addition, some Core MQTT reserved topic names were incorrectly treated as prefixes when they are specific names for single topics.
+For example, the topic name `errortopic` was treated as a Core MQTT topic because it begins with the reserved topic name `error`.
+
+Both of these issues have now been corrected.
+The documentation has been updated to clarify which topic names are matched as prefixes and which as complete topic names.

--- a/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
+++ b/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
@@ -14,8 +14,9 @@ build_artifact:
 ticket: MTM-67722
 version: 3000.0.19
 ---
-The [MQTT Service documentation](/device-integration/mqtt-service/#core-mqtt-topics) describes the set of MQTT topic names that will be treated as Core MQTT topics.
-These topics can only be used with Core MQTT protocols and must not be used by "generic" MQTT devices.
+The [MQTT Service](/device-integration/mqtt-service) treats a set of MQTT topic names as "Core MQTT" topics.
+These topics can only be used with Core MQTT protocols and must not be used by "generic MQTT" devices.
+See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for details of the Core MQTT topic set.
 
 Previously, the MQTT Service incorrectly treated any topic name containing a Core MQTT prefix as a Core MQTT topic instead of matching the prefix only at the start of the topic name.
 For example, the topic name `sensors/12345` was treated as a Core MQTT topic because it contained the reserved topic prefix `s/`.

--- a/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
+++ b/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
@@ -1,6 +1,6 @@
 ---
 date: 
-title: Fix problems with the identification of Core MQTT topics
+title: Fixed issues with the identification of Core MQTT topics
 change_type:
   - value: change-VSkj2iV9m
     label: Fix

--- a/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
+++ b/content/change-logs/platform-services/mqtt-service-3000.0.19-fix-smartrest-topic-identification.md
@@ -25,4 +25,4 @@ In addition, some Core MQTT reserved topic names were incorrectly treated as pre
 For example, the topic name `errortopic` was treated as a Core MQTT topic because it begins with the reserved topic name `error`.
 
 Both of these issues have now been corrected.
-The documentation has been updated to clarify which topic names are matched as prefixes and which as complete topic names.
+The documentation has been updated to clarify which topic names are considered to be Core MQTT topics.

--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -173,7 +173,7 @@ See the [Service Quotas](/service-terms/quotas#mqtt-service) section for details
 Certain topics are reserved for devices using the Core MQTT protcols.
 See [Core MQTT topics](#core-mqtt-topics) for the complete list.
 There is no overlap between the Core MQTT and generic device topic spaces, and all other topics are available for use by "generic" MQTT devices.
-Generic devices should avoid using any topic name starting with the Core MQTT prefixes listed below, even though some topics under those prefixes are not used by Core MQTT.
+Generic devices should avoid using any topic name treated by the MQTT Service as a Core MQTT topic, even though some of these topics are not currently used by Core MQTT.
 This will help to avoid situations where it is not obvious how a given topic should be handled, which may be difficult to debug.
 
 ### Payloads {#mqtt-payloads}
@@ -273,7 +273,9 @@ In particular:
 #### Core MQTT topics {#core-mqtt-topics}
 
 The Core MQTT protocols use a specific set of topics defined in the [MQTT quick reference](/smartrest/quick-reference/#topic-format).
-All message publication and subscription on these topics is assumed to be for Core MQTT devices and will be routed to and from the {{< product-c8y-iot >}} core.
+All messages publication and subscription on these topics is assumed to be for Core MQTT devices and will be routed to the {{< product-c8y-iot >}} core.
+
+Any topic name starting with one of the following **prefixes** is treated as a Core MQTT topic, so for example `s/e`, `s/us` and `event/events/create` are all Core MQTT topics:
 
 * `s/`
 * `t/`
@@ -283,6 +285,10 @@ All message publication and subscription on these topics is assumed to be for Co
 * `event/events/`
 * `measurement/measurements/`
 * `inventory/managedObjects/`
+
+In addition, these specific topic names are Core MQTT topics.
+These topic names are matched exactly, so `error` is a Core MQTT topic but `errortopic` is not:
+
 * `error`
 * `devicecontrol/notifications`
 

--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -273,9 +273,9 @@ In particular:
 #### Core MQTT topics {#core-mqtt-topics}
 
 The Core MQTT protocols use a specific set of topics defined in the [MQTT quick reference](/smartrest/quick-reference/#topic-format).
-All messages publication and subscription on these topics is assumed to be for Core MQTT devices and will be routed to the {{< product-c8y-iot >}} core.
+The MQTT Service assumes that all publication and subscription activity on these topics is for Core MQTT devices and routes messages to and from the {{< product-c8y-iot >}} core.
 
-Any topic name starting with one of the following **prefixes** is treated as a Core MQTT topic, so for example `s/e`, `s/us` and `event/events/create` are all Core MQTT topics:
+The MQTT Service treats any topic name that starts with one of the following **prefixes** as a Core MQTT topic. For example, `s/e`, `s/us`, and `event/events/create` are Core MQTT topics:
 
 * `s/`
 * `t/`

--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -272,25 +272,17 @@ In particular:
 
 #### Core MQTT topics {#core-mqtt-topics}
 
-The Core MQTT protocols use a specific set of topics defined in the [MQTT quick reference](/smartrest/quick-reference/#topic-format).
+The Core MQTT protocols use a specific set of topic names and topic name prefixes.
 The MQTT Service assumes that all publication and subscription activity on these topics is for Core MQTT devices and routes messages to and from the {{< product-c8y-iot >}} core.
+A device may use both Core MQTT and generic topics, but messages on a given topic will always be routed to _either_ the {{<product-c8y-iot >}} core _or_ to a generic messaging service client, never to both.
 
-The MQTT Service treats any topic name that starts with one of the following **prefixes** as a Core MQTT topic. For example, `s/e`, `s/us`, and `event/events/create` are Core MQTT topics:
+The following topic names are handled as Core MQTT topics:
 
-* `s/`
-* `t/`
-* `q/`
-* `c/`
-* `alarm/alarms/`
-* `event/events/`
-* `measurement/measurements/`
-* `inventory/managedObjects/`
+1. The SmartREST topics documented in the [MQTT quick reference](/smartrest/quick-reference/#topic-format). 
+2. The JSON via MQTT topics documented in [JSON via MQTT](/smartrest/json-via-mqtt/#topic-structure). These are matched as _prefixes_ so any topic name _starting with_ a JSON via MQTT topic name is considered to be a Core MQTT topic. For backwards compatibility, these topic names are also accepted with a leading slash (`/`) character.
+3. The special topics `error` and `devicecontrol/notifications`. These are matched _exactly_, so names such as `errorTopic` or `/error` are _not_ considered to be Core MQTT topics.
 
-In addition, these specific topic names are Core MQTT topics.
-These topic names are matched exactly, so `error` is a Core MQTT topic but `errortopic` is not:
-
-* `error`
-* `devicecontrol/notifications`
+We strongly recommend that generic MQTT devices avoid using any topic names that could be confused with Core MQTT topics.
 
 #### Connect-time behaviour {#core-mqtt-connections}
 


### PR DESCRIPTION
See https://cumulocity.atlassian.net/browse/MTM-67722 for the issue and https://github.com/Cumulocity-IoT/c8y-mqtt-service/pull/588 for the fix.