### PR TITLE
[DM-7242] Announce Sigfox Service Status callback deprecation

### DIFF
--- a/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
+++ b/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
@@ -1,0 +1,66 @@
+---
+date: '2026-09-09'
+title: Sigfox discontinues the Service Status callback used for battery and temperature measurements
+product_area: Device management & connectivity
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: component-TCiiCOknp5
+    label: LPWAN
+build_artifact:
+  - value: tc-CB45dexyZ
+    label: sigfox-agent
+ticket: DM-7242
+version:
+environment_availability:
+  - label: eu-latest.cumulocity.com
+  - label: apj.cumulocity.com
+  - label: jp.cumulocity.com
+  - label: emea.cumulocity.com
+  - label: us.cumulocity.com
+  - label: cumulocity.com
+---
+**Context**
+
+Sigfox has announced in its backend release 15.5 that the Service Status callback service is being phased out. This is a decision by Sigfox about its own platform and is outside the control of {{< product-c8y-iot >}}. The Sigfox timeline is:
+
+- **September 2026**: The Sigfox backend no longer accepts the creation of new Service Status callbacks.
+- **April 2027**: The Sigfox backend discontinues the Service Status callback service entirely. Existing Service Status callbacks stop delivering data.
+
+The Sigfox agent has so far registered a Service Status callback (`sigfoxServiceStatusCallback`) for every Sigfox device type. This callback receives the Sigfox out-of-band (OOB) status messages and turns them into two measurements on each Sigfox device:
+
+- `c8y_BatteryMeasurement` with the battery voltage reported by the device.
+- `c8y_TemperatureMeasurement` with the device temperature.
+
+Sigfox provides no replacement callback that carries battery or temperature values. Sigfox recommends that devices transmit this information in their regular application messages instead. See the [Sigfox Cloud Integration](https://build.sigfox.com/backend-callbacks-and-api) documentation.
+
+**Change**
+
+The Sigfox agent stops registering the Service Status callback for new device types, because the Sigfox backend rejects it from September 2026. When Sigfox rejects the Service Status callback during device registration, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm and logs the rejection instead. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be registered and monitored as before.
+
+**Consequence**
+
+- Sigfox devices that are registered with a **new device type** from September 2026 do not receive `c8y_BatteryMeasurement` and `c8y_TemperatureMeasurement` measurements from Sigfox status messages.
+- Sigfox devices that belong to a device type with an **existing** Service Status callback continue to receive these measurements until Sigfox discontinues the service in April 2027.
+- From April 2027, no Sigfox device receives battery or temperature measurements from Sigfox status messages anymore.
+- Anything that depends on these two measurements stops updating. This includes dashboards and data point widgets, smart rules and alarms on battery level or temperature, data exports, and integrations that query these measurement types through the Measurement API.
+
+**Persona**
+
+This change affects all users and integrators who operate Sigfox devices through {{< product-c8y-iot >}} and use the automatically created battery voltage or device temperature measurements.
+
+**Action**
+
+We recommend that you plan the migration before April 2027:
+
+1. **Check whether you are affected.** Query the Measurement API for your Sigfox devices with `type=c8y_BatteryMeasurement` or `type=c8y_TemperatureMeasurement`, or check the **Measurements** tab of a Sigfox device in the Device Management application. If these measurements are present, review which dashboards, smart rules, alarms, and integrations use them.
+2. **Change the device firmware** so that the device transmits battery voltage and temperature as part of its regular Sigfox application payload, as recommended by Sigfox.
+3. **Map the payload in the device protocol.** In **Device Management** > **Device types** > **Device protocols**, open the Sigfox device protocol of the affected device type and add the byte ranges that carry battery voltage and temperature. Select **Send measurement** as the action. To keep existing dashboards and rules working, use the same fragment and series names as before, that is `c8y_BatteryMeasurement` with the series `c8y_Battery.level` in the unit `V`, and `c8y_TemperatureMeasurement` with the series `c8y_TemperatureMeasurement.T` in the unit `C`. See [Creating device protocols](/device-integration/lpwan/#sigfox-creating-device-protocols).
+4. **Update dependent configuration** if you decide to use different fragment or series names, for example data point selections in dashboards, smart rules, and any external integrations that filter on the measurement type.
+
+If your devices cannot be changed to transmit battery and temperature values in their application messages, be aware that these values are not available in {{< product-c8y-iot >}} after April 2027.
+
+**Documentation**
+
+See [Sigfox](/device-integration/lpwan/#sigfox) in the device integration documentation.

--- a/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
+++ b/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
@@ -37,7 +37,7 @@ Sigfox provides no replacement callback that carries battery or temperature valu
 
 **Change**
 
-The Sigfox agent continues to request the Service Status callback for every new device type, so the callback is still created as long as the Sigfox backend accepts it. Once the Sigfox backend rejects the request, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm for this specific callback and logs the rejection instead. Device type registration completes without an alarm as long as all other callbacks are created successfully. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be created and monitored as before.
+The Sigfox agent continues to request the Service Status callback for every new device type, so the callback is still created as long as the Sigfox backend accepts it. Once the Sigfox backend rejects the request, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm for this specific callback. Device type registration completes without an alarm as long as all other callbacks are created successfully. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be created and monitored as before.
 
 **Consequence**
 

--- a/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
+++ b/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
@@ -37,11 +37,11 @@ Sigfox provides no replacement callback that carries battery or temperature valu
 
 **Change**
 
-The Sigfox agent stops registering the Service Status callback for new device types, because the Sigfox backend rejects it from September 2026. When Sigfox rejects the Service Status callback during device registration, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm and logs the rejection instead. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be registered and monitored as before.
+The Sigfox agent continues to request the Service Status callback for every new device type, so the callback is still created for as long as the Sigfox backend accepts it. Once the Sigfox backend rejects the request, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm for this specific callback and logs the rejection instead. Device type registration completes without an alarm as long as all other callbacks are created successfully. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be created and monitored as before.
 
 **Consequence**
 
-- Sigfox devices that are registered with a **new device type** from September 2026 do not receive `c8y_BatteryMeasurement` and `c8y_TemperatureMeasurement` measurements from Sigfox status messages.
+- Sigfox devices that are registered with a **new device type** after the Sigfox backend starts rejecting the Service Status callback (September 2026) do not receive `c8y_BatteryMeasurement` and `c8y_TemperatureMeasurement` measurements from Sigfox status messages.
 - Sigfox devices that belong to a device type with an **existing** Service Status callback continue to receive these measurements until Sigfox discontinues the service in April 2027.
 - From April 2027, no Sigfox device receives battery or temperature measurements from Sigfox status messages anymore.
 - Anything that depends on these two measurements stops updating. This includes dashboards and data point widgets, smart rules and alarms on battery level or temperature, data exports, and integrations that query these measurement types through the Measurement API.

--- a/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
+++ b/content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md
@@ -37,7 +37,7 @@ Sigfox provides no replacement callback that carries battery or temperature valu
 
 **Change**
 
-The Sigfox agent continues to request the Service Status callback for every new device type, so the callback is still created for as long as the Sigfox backend accepts it. Once the Sigfox backend rejects the request, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm for this specific callback and logs the rejection instead. Device type registration completes without an alarm as long as all other callbacks are created successfully. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be created and monitored as before.
+The Sigfox agent continues to request the Service Status callback for every new device type, so the callback is still created as long as the Sigfox backend accepts it. Once the Sigfox backend rejects the request, the Sigfox agent no longer raises a CRITICAL `c8y_ProviderCallbackAlarm_<deviceTypeId>` alarm for this specific callback and logs the rejection instead. Device type registration completes without an alarm as long as all other callbacks are created successfully. All other callbacks (uplink data, service acknowledge, error, and advanced data) are not affected and continue to be created and monitored as before.
 
 **Consequence**
 

--- a/content/device-integration/lpwan-bundle/sigfox.md
+++ b/content/device-integration/lpwan-bundle/sigfox.md
@@ -332,7 +332,7 @@ On receiving an uplink message, the {{< product-c8y-iot >}} platform creates the
 {{< c8y-admon-important >}}
 Sigfox is discontinuing its Service Status callback service. This callback delivered the Sigfox out-of-band (OOB) status messages that the Sigfox agent turned into the `c8y_BatteryMeasurement` (battery voltage) and `c8y_TemperatureMeasurement` (device temperature) measurements.
 
-- From September 2026, the Sigfox backend no longer accepts new Service Status callbacks. Devices registered with a new device type do not receive these two measurements.
+- From September 2026, the Sigfox backend no longer accepts new Service Status callbacks. The Sigfox agent still requests the callback for every new device type, but Sigfox rejects it. Devices registered with a new device type therefore do not receive these two measurements.
 - From April 2027, Sigfox discontinues the service entirely. No Sigfox device receives these two measurements anymore.
 
 This is a change on the Sigfox side and cannot be compensated by {{< product-c8y-iot >}}, because no other Sigfox callback carries battery or temperature values. If you rely on these measurements, for example in dashboards, smart rules, or integrations, transmit battery voltage and temperature in the regular application payload of your device, as recommended by Sigfox, and map them to measurements in your [device protocol](#sigfox-creating-device-protocols). Use the same fragment and series names to keep existing dashboards and rules working.
@@ -422,7 +422,7 @@ The status is updated asynchronously which means that sometimes you might have t
 This alarm is created when one or more callback creation requests have failed in the Sigfox platform. You can view the alarm either in the **Alarms** page or in the **Home** page.
 
 {{< c8y-admon-info >}}
-The Sigfox backend rejects the creation of Service Status callbacks (type `SERVICE_STATUS`) since September 2026, because Sigfox is discontinuing this callback service. The Sigfox agent does not raise this alarm for a rejected Service Status callback. The rejection is only written to the microservice log. Do not create the Service Status callback manually. See [Uplink message processing](#sigfox-uplink-message-processing) for the impact on battery and temperature measurements.
+The Sigfox backend rejects the creation of Service Status callbacks (type `SERVICE_STATUS`) since September 2026, because Sigfox is discontinuing this callback service. The Sigfox agent still requests this callback during device type registration, but it does not raise this alarm when Sigfox rejects it. The rejection is only written to the microservice log. Do not create the Service Status callback manually. See [Uplink message processing](#sigfox-uplink-message-processing) for the impact on battery and temperature measurements.
 {{< /c8y-admon-info >}}
 
 In order to fix this issue, navigate to the Sigfox platform web interface and check the device type with the id mentioned in the alarm.

--- a/content/device-integration/lpwan-bundle/sigfox.md
+++ b/content/device-integration/lpwan-bundle/sigfox.md
@@ -329,6 +329,15 @@ On receiving an uplink message, the {{< product-c8y-iot >}} platform creates the
 - **Position** - The <code>c8y_Position</code> fragment of the device managed object is updated to capture the latitude, longitude, altitude and accuracy information of the device.
 - **Signal strength** - A measurement is created with RSSI and SNR values of the device signal strength.
 
+{{< c8y-admon-important >}}
+Sigfox is discontinuing its Service Status callback service. This callback delivered the Sigfox out-of-band (OOB) status messages that the Sigfox agent turned into the `c8y_BatteryMeasurement` (battery voltage) and `c8y_TemperatureMeasurement` (device temperature) measurements.
+
+- From September 2026, the Sigfox backend no longer accepts new Service Status callbacks. Devices registered with a new device type do not receive these two measurements.
+- From April 2027, Sigfox discontinues the service entirely. No Sigfox device receives these two measurements anymore.
+
+This is a change on the Sigfox side and cannot be compensated by {{< product-c8y-iot >}}, because no other Sigfox callback carries battery or temperature values. If you rely on these measurements, for example in dashboards, smart rules, or integrations, transmit battery voltage and temperature in the regular application payload of your device, as recommended by Sigfox, and map them to measurements in your [device protocol](#sigfox-creating-device-protocols). Use the same fragment and series names to keep existing dashboards and rules working.
+{{< /c8y-admon-important >}}
+
 ### Troubleshooting {#sigfox-troubleshooting}
 
 #### Device registration {#device-registration}
@@ -411,6 +420,10 @@ The status is updated asynchronously which means that sometimes you might have t
 ![Callback creation failed](/images/device-protocols/sigfox/sigfox-troubleshooting-callback.png)
 
 This alarm is created when one or more callback creation requests have failed in the Sigfox platform. You can view the alarm either in the **Alarms** page or in the **Home** page.
+
+{{< c8y-admon-info >}}
+The Sigfox backend rejects the creation of Service Status callbacks (type `SERVICE_STATUS`) since September 2026, because Sigfox is discontinuing this callback service. The Sigfox agent does not raise this alarm for a rejected Service Status callback. The rejection is only written to the microservice log. Do not create the Service Status callback manually. See [Uplink message processing](#sigfox-uplink-message-processing) for the impact on battery and temperature measurements.
+{{< /c8y-admon-info >}}
 
 In order to fix this issue, navigate to the Sigfox platform web interface and check the device type with the id mentioned in the alarm.
 


### PR DESCRIPTION
## Summary

Jira: [DM-7242](https://cumulocity.atlassian.net/browse/DM-7242)

Sigfox announced in its backend release 15.5 that the **Service Status callback** service is being phased out:

- **September 2026** – creation of new Service Status callbacks is disabled.
- **April 2027** – the Service Status callback service is discontinued entirely.

The Sigfox agent used this callback to produce `c8y_BatteryMeasurement` and `c8y_TemperatureMeasurement` for every Sigfox device. There is no replacement callback on the Sigfox side; Sigfox recommends transmitting battery and temperature in the application payload instead.

## Changes

- **New announcement changelog** `content/change-logs/device-management/sigfox-agent-DM-7242-sigfox-service-status-callback-deprecation.md` – immediate announcement (Context / Change / Consequence / Persona / Action / Documentation) that the Sigfox agent keeps requesting the Service Status callback but no longer raises a CRITICAL alarm when Sigfox rejects it, with the concrete migration steps customers need to take before April 2027.
- **Sigfox guide** `content/device-integration/lpwan-bundle/sigfox.md`
  - Important admonition under *Uplink message processing* describing the deprecation timeline and the migration path via device protocols.
  - Info admonition under *Troubleshooting → Callback creation failed* explaining that a rejected `SERVICE_STATUS` callback no longer raises the alarm and must not be created manually.

## Related

- Agent-side change: Cumulocity-IoT/c8y-sigfox-agent#128 (log instead of CRITICAL alarm when Sigfox rejects the Service Status callback).

## Notes for reviewers

- `version:` in the changelog front matter is left empty on purpose – this is a platform-independent announcement about a Sigfox-side change, not tied to an agent release.
- Sigfox references: [Sigfox Cloud Integration](https://build.sigfox.com/backend-callbacks-and-api), [OOB messages](https://support.sigfox.com/docs/out-of-band-(oob)-messages).

_This PR was drafted with AI assistance (Claude Code) and reviewed by the author._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DM-7242]: https://cumulocity.atlassian.net/browse/DM-7242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ