### PR TITLE
Add CODEOWNERS entry for streaming-lake-ingestion-bundle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /content/console/ @bbyreddy @tydunne @BeateRixen
 /content/data-broker/ @scmi-c8y @BeateRixen
 /content/datahub/ @cheinz-sag @BeateRixen
+/content/datahub/streaming-lake-ingestion-bundle/ @eickler @jaro-herod @riemenschneider @afri-c8y @flsc-c8y @BeateRixen
 /content/device-certificate-authentication/ @mgrumann @BeateRixen
 /content/device-integration/ @Oezge-Akin @l2p- @eliasweingaertner
 /content/device-integration/mqtt*.md @scmi-c8y @BeateRixen


### PR DESCRIPTION
Add the Iceflow developers as code owners for the according user documentation.