### PR TITLE
docs(change-logs): DM-7013 [Fix] Add changelog for the scheduled bulk operation recovery after a node restart

### DIFF
--- a/content/change-logs/device-management/cumulocity-2026-313-0-scheduled-bulk-operations-recovered-after-a-platform-restart.md
+++ b/content/change-logs/device-management/cumulocity-2026-313-0-scheduled-bulk-operations-recovered-after-a-platform-restart.md
@@ -1,0 +1,23 @@
+---
+date: ""
+title: Fixed delayed start of scheduled bulk operations after a platform restart
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Device management & connectivity
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: DM-7013
+version: 2026.313.0
+---
+A bulk operation is carried out by a single node of the platform, which keeps the plan for the remaining devices in memory. When a bulk operation was scheduled to start at a future time and that node restarted before the start time was reached, the plan was lost. Nothing restored it, and the bulk operation was only picked up again by the general recovery mechanism, which by design takes effect after the planned start time has already passed. In the worst case, a bulk operation started up to 13 hours later than the time it was scheduled for. This was most likely to happen when the platform was upgraded between the moment a bulk operation was created and the moment it was due to start.
+
+Scheduled bulk operations are now restored when a node restarts, and they start at the time they were scheduled for. This also covers the case where the node that was carrying out the bulk operation is replaced by a different one, which is what happens during a rolling platform upgrade.
+
+A bulk operation whose node stops while its device operations are still being created is now also taken over within minutes, instead of waiting for the abandonment timeout to elapse.
+
+Each device still receives exactly one operation per bulk operation, and existing installations require no configuration changes.

--- a/content/change-logs/device-management/cumulocity-2026-313-0-scheduled-bulk-operations-recovered-after-a-platform-restart.md
+++ b/content/change-logs/device-management/cumulocity-2026-313-0-scheduled-bulk-operations-recovered-after-a-platform-restart.md
@@ -14,10 +14,6 @@ build_artifact:
 ticket: DM-7013
 version: 2026.313.0
 ---
-A bulk operation is carried out by a single node of the platform, which keeps the plan for the remaining devices in memory. When a bulk operation was scheduled to start at a future time and that node restarted before the start time was reached, the plan was lost. Nothing restored it, and the bulk operation was only picked up again by the general recovery mechanism, which by design takes effect after the planned start time has already passed. In the worst case, a bulk operation started up to 13 hours later than the time it was scheduled for. This was most likely to happen when the platform was upgraded between the moment a bulk operation was created and the moment it was due to start.
+A bulk operation scheduled to start at a future time could start significantly later than scheduled if the platform was restarted before its start time was reached, for example during a platform upgrade. This issue is now fixed, and scheduled bulk operations start at the time they were scheduled for.
 
-Scheduled bulk operations are now restored when a node restarts, and they start at the time they were scheduled for. This also covers the case where the node that was carrying out the bulk operation is replaced by a different one, which is what happens during a rolling platform upgrade.
-
-A bulk operation whose node stops while its device operations are still being created is now also taken over within minutes, instead of waiting for the abandonment timeout to elapse.
-
-Each device still receives exactly one operation per bulk operation, and existing installations require no configuration changes.
+Failover handling has also been improved for bulk operations that are interrupted while they are being carried out, so that their execution resumes noticeably faster.


### PR DESCRIPTION
Changelog entry for **DM-7013**, shipping in `cumulocity` **2026.313.0**.

Source change: Cumulocity-IoT/cumulocity-core#4827 (merged to `develop`; the release-version commit immediately after it is `2026.313.0`).

A bulk operation scheduled for a future time could start significantly later than scheduled when the platform was restarted before its start time was reached — most commonly during a platform upgrade. Bulk operations interrupted while running also took longer than necessary to resume. The entry describes both from the user's point of view only; per review feedback it deliberately contains no implementation detail about how the platform schedules, distributes or recovers bulk operations.

Fields follow the previous bulk-operations entry for this component (DM-5040, `cumulocity-2026.6.0-bulk-device-operations-count-fix-revisited.md`): same `change_type`, `product_area`, `component` and `build_artifact`. `date` is left empty for the deployment-date automation, and `environment_availability` is omitted, matching the most recent entries.

The same fix was grafted to the 2026 release line; that entry is a separate PR (version `2026.0.115`), Cumulocity-IoT/c8y-docs#5146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
