### PR TITLE
docs(change-logs): DM-7013 [Fix] Add changelog for the scheduled bulk operation recovery after a node restart

### DIFF
--- a/content/change-logs/device-management/cumulocity-2026-0-115-scheduled-bulk-operations-recovered-after-a-platform-restart.md
+++ b/content/change-logs/device-management/cumulocity-2026-0-115-scheduled-bulk-operations-recovered-after-a-platform-restart.md
@@ -1,0 +1,23 @@
+---
+date: ""
+title: Fixed delayed start of scheduled bulk operations after a platform restart
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Device management & connectivity
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: DM-7013
+version: 2026.0.115
+---
+A bulk operation is carried out by a single node of the platform, which keeps the plan for the remaining devices in memory. When a bulk operation was scheduled to start at a future time and that node restarted before the start time was reached, the plan was lost. Nothing restored it, and the bulk operation was only picked up again by the general recovery mechanism, which by design takes effect after the planned start time has already passed. In the worst case, a bulk operation started up to 13 hours later than the time it was scheduled for. This was most likely to happen when the platform was upgraded between the moment a bulk operation was created and the moment it was due to start.
+
+Scheduled bulk operations are now restored when a node restarts, and they start at the time they were scheduled for. This also covers the case where the node that was carrying out the bulk operation is replaced by a different one, which is what happens during a rolling platform upgrade.
+
+A bulk operation whose node stops while its device operations are still being created is now also taken over within minutes, instead of waiting for the abandonment timeout to elapse.
+
+Each device still receives exactly one operation per bulk operation, and existing installations require no configuration changes.

--- a/content/change-logs/device-management/cumulocity-2026-0-115-scheduled-bulk-operations-recovered-after-a-platform-restart.md
+++ b/content/change-logs/device-management/cumulocity-2026-0-115-scheduled-bulk-operations-recovered-after-a-platform-restart.md
@@ -14,10 +14,6 @@ build_artifact:
 ticket: DM-7013
 version: 2026.0.115
 ---
-A bulk operation is carried out by a single node of the platform, which keeps the plan for the remaining devices in memory. When a bulk operation was scheduled to start at a future time and that node restarted before the start time was reached, the plan was lost. Nothing restored it, and the bulk operation was only picked up again by the general recovery mechanism, which by design takes effect after the planned start time has already passed. In the worst case, a bulk operation started up to 13 hours later than the time it was scheduled for. This was most likely to happen when the platform was upgraded between the moment a bulk operation was created and the moment it was due to start.
+A bulk operation scheduled to start at a future time could start significantly later than scheduled if the platform was restarted before its start time was reached, for example during a platform upgrade. This issue is now fixed, and scheduled bulk operations start at the time they were scheduled for.
 
-Scheduled bulk operations are now restored when a node restarts, and they start at the time they were scheduled for. This also covers the case where the node that was carrying out the bulk operation is replaced by a different one, which is what happens during a rolling platform upgrade.
-
-A bulk operation whose node stops while its device operations are still being created is now also taken over within minutes, instead of waiting for the abandonment timeout to elapse.
-
-Each device still receives exactly one operation per bulk operation, and existing installations require no configuration changes.
+Failover handling has also been improved for bulk operations that are interrupted while they are being carried out, so that their execution resumes noticeably faster.


### PR DESCRIPTION
Changelog entry for **DM-7013** on the **2026 release line**, shipping in `cumulocity` **2026.0.115**.

Source change: Cumulocity-IoT/cumulocity-core#4849 — the graft of Cumulocity-IoT/cumulocity-core#4827 to `release/y2026`.

Replaces #5145, which was branched from and targeted `develop` by mistake. This one is branched from and targets `release/y2026`.

Companion entry for the develop line is Cumulocity-IoT/c8y-docs#5144 (version `2026.313.0`). The body text is identical; only the `version` field differs. As agreed in review, the text stays on the user-visible behaviour and carries no implementation detail.

Fields follow the DM-5040 entry already on this branch (`cumulocity-2026-0-4-bulk-device-operations-count-fix-revisited.md`) — same `change_type`, `product_area`, `component` and `build_artifact`, and no `-graft` suffix on the filename, since on the release branch this simply is the release-line entry.

⚠️ **One thing to confirm before merging:** `2026.0.115` is inferred, not yet observed. `release/y2026` in cumulocity-core currently has the graft merged on top of `chore(release): updated development version to 2026.0.115`, and the newest release cut is still `2026.0.114`. If the release lands under a different number, this entry needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
